### PR TITLE
module files placed in install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ list ( APPEND cvmix_files
 	${cvmix_shared_files}
 )
 
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
+endif()
+
 ################################################################################
 # Library
 ################################################################################


### PR DESCRIPTION
fortran module files were not placed correctly when doing a `make install`